### PR TITLE
Fixed the API example for @supports.

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -2076,7 +2076,7 @@
         "name": "Conditional Rules",
         "category": "CSS",
         "link": "http://dev.w3.org/csswg/css-conditional/",
-        "summary": "Support for the @supports at-rule and the \"window.DOM.supports()\" API",
+        "summary": "Support for the @supports at-rule and the \"window.CSS.supports()\" API",
         "standardStatus": "Established standard",
         "ieStatus": {
             "text": "In Development",


### PR DESCRIPTION
The API is not DOM.supports, but CSS.supports. Changed it.
