### PR TITLE
Fixed the interop (and term?) query string filter

### DIFF
--- a/app/scripts/directives/termfilter.js
+++ b/app/scripts/directives/termfilter.js
@@ -12,7 +12,7 @@ angular.module('statusieApp')
 
                 var filter = function () {
                     $scope.$emit('filterupdated', {
-                        name: 'interop',
+                        name: 'term',
                         filterFunction: filterFunction($scope.term)
                     });
                 };


### PR DESCRIPTION
The term based query string filter was wrongly using the "interop" key and thus did not work in itself and broke the interop based query string filter as well.
Note that this issue is only apparent in the minified version of the scripts for some reason. When using the separate, original scripts, it works.

For example -
http://status.modern.ie/?iestatuses=indevelopment&browserstatuses=notsupported,indevelopment,implemented&browsers=chrome,firefox,opera,safari&ieversion=11 or http://status.modern.ie/?iestatuses=indevelopment or http://status.modern.ie/?iestatuses=indevelopment&browserstatuses=&browsers=&ieversion=11
Always show all of the features instead of only in development (in Internet Explorer) features, in status.modern.ie.
However, in the local version, they only show 24 features.

Changed the "interop" key to "term".
