### PR TITLE
Fixed an insecure reference and added vote sorting

### DIFF
--- a/app/scripts/directives/featuresorting.js
+++ b/app/scripts/directives/featuresorting.js
@@ -53,7 +53,7 @@ angular.module('statusieApp')
                             if (!feature.uservoice) {
                                 return 0;
                             }
-                            return feature.uservoice.votes;
+                            return -feature.uservoice.votes;
                         }}
                 ];
                 $scope.sorts = sorts;

--- a/app/scripts/directives/featuresorting.js
+++ b/app/scripts/directives/featuresorting.js
@@ -46,7 +46,15 @@ angular.module('statusieApp')
 
                             return statusOrder[feature.position.toLowerCase()];
                         }
-                    }
+                    },
+                    {
+                        name: 'votes',
+                        sortFunction: function (feature) {
+                            if (!feature.uservoice) {
+                                return 0;
+                            }
+                            return feature.uservoice.votes;
+                        }}
                 ];
                 $scope.sorts = sorts;
 

--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -10,8 +10,8 @@
 
 @font-face {
     font-family: "Segoe Custom";
-    src: url("http://www.modern.ie/cdn/fonts/west-european/normal/latest.eot");
-    src: local("Segoe UI"), url("http://www.modern.ie/cdn/fonts/west-european/normal/latest.woff") format("woff");
+    src: url("//www.modern.ie/cdn/fonts/west-european/normal/latest.eot");
+    src: local("Segoe UI"), url("//www.modern.ie/cdn/fonts/west-european/normal/latest.woff") format("woff");
 }
 
 * {


### PR DESCRIPTION
- The font referenced an HTTP URL, while the site is always served from HTTPS and a mixed content policy was blocking the font (in Chrome, at least). So I fixed the reference to be scheme agnostic.
- Added a new sorting option - sort by UserVoice votes, for greater transparency.
