### PR TITLE
Fixed the icon opacity for preview features

### DIFF
--- a/app/templates/feature.html
+++ b/app/templates/feature.html
@@ -50,7 +50,7 @@
                           data-bo-text="feature.browsers.firefox.status + ' by Firefox'"></span>
                 </li>
                 <li 
-                    data-bo-class="{'implemented': feature.browsers.ie.status === 'Shipped' || feature.browsers.ie.status === 'Prefixed' || feature.browsers.ie.status === 'IE Developer Channel' || feature.browsers.ie.status === 'Deprecated', 'indevelopment' : feature.browsers.ie.status === 'In Development', 'icon-ie': feature.browsers.ie.status !== 'Deprecated', 'icon-ie-deprecated': feature.browsers.ie.status === 'Deprecated'}"
+                    data-bo-class="{'implemented': feature.browsers.ie.status === 'Shipped' || feature.browsers.ie.status === 'Prefixed' || feature.browsers.ie.status === 'Preview Release' || feature.browsers.ie.status === 'IE Developer Channel' || feature.browsers.ie.status === 'Deprecated', 'indevelopment' : feature.browsers.ie.status === 'In Development', 'icon-ie': feature.browsers.ie.status !== 'Deprecated', 'icon-ie-deprecated': feature.browsers.ie.status === 'Deprecated'}"
                     data-bo-title="feature.browsers.ie.status==='Preview Release' ? 'Available for preview in IE' : feature.browsers.ie.status + ' by Internet Explorer'">
                     <a data-bo-if="feature.browsers.ie.link" data-bo-href="feature.browsers.ie.link"
                        data-bo-text="feature.browsers.ie.status + ' by Internet Explorer'" target="_blank"></a>


### PR DESCRIPTION
Fixed https://github.com/InternetExplorer/Status.IE/issues/145 by adding another status condition to the icon in the feature template.
