### PR TITLE
Revert "Update Media Queries Level 4 W3C link"

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -2607,7 +2607,7 @@
     {
         "name": "Media Queries Level 4: Interaction Media Features (pointer and hover)",
         "category": "CSS",
-        "link": "http://dev.w3.org/csswg/mediaqueries-4/#mf-interaction",
+        "link": "http://dev.w3.org/csswg/mediaqueries4/#mf-interaction",
         "summary": "Allows to query the presence and accuracy of the user's pointing input (e.g. for differentiating touch versus mouse). Additionally, allows the page to query whether the user's pointing input supports hover.",
         "standardStatus": "Working draft or equivalent",
         "ieStatus": {


### PR DESCRIPTION
Reverts InternetExplorer/Status.IE#204
Merged into a branch that's way behind, which caused conflicts. Let's take this directly into production instead.
