### PR TITLE
Update id for Template Strings (ES6)

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -3029,17 +3029,7 @@
       "iePrefixed": "",
       "ieUnprefixed": ""
     },
-    "impl_status_chrome": "No active development",
-    "shipped_opera_milestone": false,
-    "ff_views": {
-      "text": "Shipped",
-      "value": 1
-    },
-    "safari_views": {
-      "text": "No Signals",
-      "value": 3
-    },
-    "id": null
+    "id": 4743002513735680
   },
   {
     "name": "Tail Calls (ES6)",


### PR DESCRIPTION
Use Chromium status id rather than outdated static info for the Template Strings (ES6) feature.

https://www.chromestatus.com/feature/4743002513735680
