### PR TITLE
Fixed the cross domain font loading data

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -1055,12 +1055,8 @@
     "wpd": "",
     "demo": "",
     "id": null,
-    "impl_status_chrome": "Enabled by default",
-    "ff_views": {
-      "text": "Shipped",
-      "value": 1
-    },
-    "shipped_opera_milestone": true,
+    "impl_status_chrome": "Removed",
+    "shipped_opera_milestone": null,
     "safari_views": {
       "text": "Shipped",
       "value": 1


### PR DESCRIPTION
Firefox never shipped it (according to https://developer.mozilla.org/en/docs/Web/CSS/@font-face anyway) and Chrome removed support for this months ago. See https://www.chromestatus.com/features/4708736996212736 for details.
