### PR TITLE
Added WebKit data

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -2993,7 +2993,8 @@
       "ieUnprefixed": ""
     },
     "id": 4633745457938432,
-    "uservoiceid": 6510201
+    "uservoiceid": 6510201,
+    "webkitName": "Classes"
   },
   {
     "name": "Spread (ES6)",
@@ -3136,7 +3137,8 @@
       "value": 3
     },
     "id": null,
-    "uservoiceid": 6509389
+    "uservoiceid": 6509389,
+    "webkitName": "ASM.js"
   },
   {
     "name": "Clipboard API",
@@ -3445,7 +3447,8 @@
     "msdn": "",
     "wpd": "",
     "demo": "",
-    "id": null
+    "id": null,
+    "webkitName": "Shared Web Workers"
   },
   {
     "name": "Platform for Privacy Preferences 1.0 (P3P 1.0)",
@@ -3882,7 +3885,7 @@
     "wpd": "",
     "demo": "",
     "id": null,
-    "uservoiceid": null
+    "uservoiceclid": null
   },
       {
     "name": "showModalDialog",

--- a/app/templates/feature.html
+++ b/app/templates/feature.html
@@ -54,7 +54,7 @@
                 </li>
                 <li 
                     data-bo-class="{'implemented': feature.browsers.ie.status === 'Shipped' || feature.browsers.ie.status === 'Prefixed' || feature.browsers.ie.status === 'Preview Release' || feature.browsers.ie.status === 'Deprecated', 'indevelopment' : feature.browsers.ie.status === 'In Development', 'icon-ie': feature.browsers.ie.status !== 'Deprecated', 'icon-ie-deprecated': feature.browsers.ie.status === 'Deprecated'}"
-                    data-bo-title="feature.browsers.ie.status==='Preview Release' ? 'Available for preview in IE' : feature.browsers.ie.status + ' by Internet Explorer'">
+                    data-bo-title="feature.browsers.ie.status === 'Preview Release' ? 'Available for preview in IE' : feature.browsers.ie.status + ' by Internet Explorer'">
                     <a data-bo-if="feature.browsers.ie.link" data-bo-href="feature.browsers.ie.link"
                        data-bo-text="feature.browsers.ie.status + ' by Internet Explorer'" target="_blank"></a>
                     <span data-bo-if="!feature.browsers.ie.link"
@@ -69,10 +69,10 @@
                           data-bo-text="feature.browsers.opera.status + ' by Opera'"></span>
                 </li>
                 <li class="icon-safari"
-                    data-bo-class="{'implemented': feature.browsers.safari.status === 'Shipped' || feature.browsers.safari.status === 'Prefixed', 'indevelopment' : feature.browsers.safari.status === 'In Development'}"
-                    data-bo-title="feature.browsers.safari.status + ' by Safari'">
+                    data-bo-class="{'implemented': feature.browsers.safari.status === 'Shipped' || feature.browsers.safari.status === 'Prefixed', 'indevelopment' : feature.browsers.safari.status === 'In Development' || feature.browsers.safari.status === 'Preview Release'}"
+                    data-bo-title="feature.browsers.safari.status === 'Preview Release' ? 'Available for preview in WebKit Nightly' : feature.browsers.safari.status + ' by Safari'">
                     <a data-bo-if="feature.browsers.safari.link" data-bo-href="feature.browsers.safari.link "
-                       data-bo-text="feature.browsers.safari.status + ' by  Safari'" target="_blank"></a>
+                       data-bo-text="feature.browsers.safari.status + ' by Safari'" target="_blank"></a>
                     <span data-bo-if="!feature.browsers.safari.link"
                           data-bo-text="feature.browsers.safari.status + ' by Safari'"></span>
                 </li>


### PR DESCRIPTION
WebKit publishes its status data at http://www.webkit.org/status.html, using two JSONs (WebCore and JavaScriptCore). This pull request adds the data to status.modern.ie.

This fixes https://github.com/InternetExplorer/Status.IE/issues/223.
