### PR TITLE
Added backdrop-filter to the feature list

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -4228,6 +4228,33 @@
     "uservoiceid": null
   },
   {
+    "name": "Backdrop filter",
+    "category": "CSS",
+    "link": "http://dev.w3.org/fxtf/filters-2/#BackdropFilterProperty",
+    "summary": "Applies a CSS filter effect to the content behind an element. This is not the element's background but the content that would be drawn behind it.",
+    "standardStatus": "Working draft or equivalent",
+    "ieStatus": {
+      "text":"Not currently planned",
+      "iePrefixed": "",
+      "ieUnprefixed": ""
+    },
+    "impl_status_chrome": "In Development",
+    "ff_views": {
+      "text": "No public signals",
+      "value": 5
+    },
+    "safari_views": {
+      "text": "Preview release",
+      "value": 1
+    },
+    "shipped_opera_milestone": false,
+    "msdn": "",
+    "wpd": "",
+    "demo": "",
+    "id": null,
+    "uservoiceid": 9160189
+  },
+  {
     "name": "International input[type=email] validation",
     "category": "User input",
     "link": "https://www.w3.org/Bugs/Public/show_bug.cgi?id=15489",

--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -4234,7 +4234,7 @@
     "summary": "Applies a CSS filter effect to the content behind an element. This is not the element's background but the content that would be drawn behind it.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text":"Not currently planned",
+      "text":"Under Consideration",
       "iePrefixed": "",
       "ieUnprefixed": ""
     },


### PR DESCRIPTION
Pull request for #253. There's no docs for the values for the different browsers so only used the ones I could see used elsewhere. Ideally Firefox would be "No Active Development" rather than "No public signals" but couldn't see it or it's correct value.
