### PR TITLE
:in-range & :out-of-range aren't prefixed in Firefox

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -300,7 +300,7 @@
     },
     "impl_status_chrome": "Enabled by default",
     "ff_views": {
-      "text": "Prefixed",
+      "text": "Shipped",
       "value": 1
     },
     "shipped_opera_milestone": true,


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/docs/Web/CSS/:out-of-range#Browser_compatibility
Testcase: http://jsfiddle.net/n0n3n53b/1/
