### PR TITLE
Add Web Bluetooth to the Edge status page.

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -3853,7 +3853,8 @@
     "summary": "An API for communicating with Bluetooth Low Energy devices as a GATT Client.",
     "standardStatus": "Editor's draft",
     "ieStatus": {
-      "text": "Not currently planned",
+      "text": "Under Consideration",
+      "priority": "low",
       "iePrefixed": "",
       "ieUnprefixed": ""
     },

--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -3847,6 +3847,32 @@
     "id": 6248386202173440
   },
   {
+    "name": "Web Bluetooth",
+    "category": "Device",
+    "link": "https://webbluetoothcg.github.io/web-bluetooth/",
+    "summary": "An API for communicating with Bluetooth Low Energy devices as a GATT Client.",
+    "standardStatus": "Editor's draft",
+    "ieStatus": {
+      "text": "Not currently planned",
+      "iePrefixed": "",
+      "ieUnprefixed": ""
+    },
+    "ff_views": {
+      "text": "In Development",
+      "value": 2
+    },
+    "safari_views": {
+      "text": "No Public Signals",
+      "value": 3
+    },
+    "impl_status_chrome": "Behind a flag",
+    "shipped_opera_milestone": false,
+    "msdn": "",
+    "wpd": "",
+    "demo": "",
+    "id": null
+  },
+  {
     "name": "Shared Web Workers",
     "category": "JavaScript",
     "link": "http://dev.w3.org/html5/workers/#shared-workers-and-the-sharedworker-interface",

--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -3857,20 +3857,11 @@
       "iePrefixed": "",
       "ieUnprefixed": ""
     },
-    "ff_views": {
-      "text": "In Development",
-      "value": 2
-    },
-    "safari_views": {
-      "text": "No Public Signals",
-      "value": 3
-    },
-    "impl_status_chrome": "Behind a flag",
-    "shipped_opera_milestone": false,
     "msdn": "",
     "wpd": "",
     "demo": "",
-    "id": null
+    "id": 5264933985976320,
+    "uservoiceid": 9775308
   },
   {
     "name": "Shared Web Workers",


### PR DESCRIPTION
In our meeting yesterday, it sounded like Edge supports Web Bluetooth, but it's low priority to implement. Is there a good way to express that under `ieStatus`?

Chrome's status page is https://www.chromestatus.com/features/5264933985976320, and Firefox's implementation bug is https://bugzilla.mozilla.org/show_bug.cgi?id=1204396, but I don't see any links to this sort of thing in `ie-status.json`. I do see an `ff_views_link` key in `features.json`. Should I add these links to `ie_status.json` under `impl_status_chrome_link` and `ff_views_link`?
