### PR TITLE
Mark status of ES6 RegExp methods as "In Development"

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -3370,9 +3370,9 @@
     "link": "http://ecma-international.org/ecma-262/6.0/index.html",
     "standardStatus": "Established Standard",
     "ieStatus": {
-      "text": "Shipped",
+      "text": "In Development",
       "iePrefixed": "",
-      "ieUnprefixed": "10240"
+      "ieUnprefixed": ""
     },
     "impl_status_chrome": "No Signals",
     "shipped_opera_milestone": false,


### PR DESCRIPTION
Status of RegExp methods are incorrectly marked as **Supported**. The Chakra team is currently working on them, so changing the status to **In Development** instead.
