### PR TITLE
Update Beacon browser support

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -2794,12 +2794,12 @@
     "wpd": "",
     "demo": "",
     "id": null,
-    "impl_status_chrome": "No active development",
+    "impl_status_chrome": "Enabled by default",
     "ff_views": {
-      "text": "No public signals",
-      "value": 5
+      "text": "Shipped",
+      "value": 1
     },
-    "shipped_opera_milestone": null,
+    "shipped_opera_milestone": 1,
     "safari_views": {
       "text": "No public signals",
       "value": 5


### PR DESCRIPTION
Try to fix #329 but I am not sure how how statuses are collected for Firefox and Opera

Maybe it is a better option to remove the lines related to Chrome, Firefox and Opera from this feature, so the data wont be overwritten from the original source.
