### PR TITLE
Added case insensitive attribute selector matching

### DIFF
--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -5186,5 +5186,21 @@
     "demo": "",
     "id": null,
     "uservoiceid": null
+  },
+  {
+    "name": "CSS Case Insensitive Attribute Selector Matching",
+    "category": "CSS",
+    "link": "https://drafts.csswg.org/selectors-4/#attribute-case",
+    "summary": "An additional modifier ('i') for attribute selectors, that allows an author to match an attribute (ASCII) case-insensitively. For example, div[data-foo=\"pop\" i] matches <div data-foo=\"pOp\">.",
+    "standardStatus": "Working draft or equivalent",
+    "ieStatus": {
+      "text": "Under Consideration",
+      "iePrefixed": "",
+      "ieUnprefixed": ""
+    },
+    "msdn": "",
+    "wpd": "",
+    "demo": "http://css4-selectors.com/selector/css4/attribute-case-sensitivity/",
+    "id": 5610936115134464
   }
 ]

--- a/app/static/ie-status.json
+++ b/app/static/ie-status.json
@@ -5188,10 +5188,10 @@
     "uservoiceid": null
   },
   {
-    "name": "CSS Case Insensitive Attribute Selector Matching",
+    "name": "CSS Selectors Level 4",
     "category": "CSS",
-    "link": "https://drafts.csswg.org/selectors-4/#attribute-case",
-    "summary": "An additional modifier ('i') for attribute selectors, that allows an author to match an attribute (ASCII) case-insensitively. For example, div[data-foo=\"pop\" i] matches <div data-foo=\"pOp\">.",
+    "link": "https://drafts.csswg.org/selectors-4/#overview",
+    "summary": "Extends the selectors with :matches, :has, :not(complex selector), :dir, case insensitive attribute matching and more.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
       "text": "Under Consideration",
@@ -5199,8 +5199,6 @@
       "ieUnprefixed": ""
     },
     "msdn": "",
-    "wpd": "",
-    "demo": "http://css4-selectors.com/selector/css4/attribute-case-sensitivity/",
-    "id": 5610936115134464
+    "wpd": ""
   }
 ]


### PR DESCRIPTION
Chrome (49, currently in beta), Safari (already) and Firefox (47, upcoming, see https://bugzilla.mozilla.org/show_bug.cgi?id=888190 for details) already support it. Edge is the odd one out and I know you do not like being the odd one out anymore. ;)
