### PR TITLE
Link to the new EdgeHTML issue tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo provides valuable data on the implementation status and future plans f
 ## Contributing
 Want to contribute to this project? We'd love to have your help!  Take a look at the [Contributing Guidelines](https://github.com/MicrosoftEdge/Status/blob/production/CONTRIBUTING.md) before you dive in. For many features, support data for browsers other than IE and Microsoft Edge comes from the [Chromium Dashboard](https://www.chromestatus.com) and bugs against that data can be filed [here](https://github.com/GoogleChrome/chromium-dashboard/issues).
 
-Note that this GitHub project is *not* for making feature requests for or reporting bugs in Internet Explorer or Microsoft Edge. Browser feedback can be provided at [Microsoft Connect](https://connect.microsoft.com/ie) and [UserVoice](https://uservoice.microsoftedge.com).
+Note that this GitHub project is *not* for making feature requests for or reporting bugs in Internet Explorer or Microsoft Edge. Browser feedback can be provided through the [issue tracker](https://developer.microsoft.com/microsoft-edge/platform/issues/) and on [UserVoice](https://uservoice.microsoftedge.com).
 
 ## Additional Attributions
 Portions of the content in this page from chromestatus.com, used under [Creative Commons Attribution 2.5 License](https://creativecommons.org/licenses/by/2.5/legalcode)


### PR DESCRIPTION
Note: httpS://issues.microsoftedge.com/ doesn't seem to work (this may be related to: https://github.com/MicrosoftEdge/Status/issues/346?).

``` bash
$ curl -sSIL https://issues.microsoftedge.com/
curl: (28) Connection timed out after 60001 milliseconds
```

Maybe link to https://developer.microsoft.com/microsoft-edge/platform/issues/?
