### PR TITLE
MicrosoftEdge should reconsider MathML support 

### DIFF
--- a/status.json
+++ b/status.json
@@ -1542,7 +1542,7 @@
     "summary": "An application of XML for describing mathematical notations and capturing both its structure and content.",
     "standardStatus": "Established standard",
     "ieStatus": {
-      "text": "Not currently planned",
+      "text": "Under Consideration",
       "iePrefixed": "",
       "ieUnprefixed": ""
     },


### PR DESCRIPTION
MathML is part of HTML5 and should be supported.
At least a guide how to render MathML elements with
third party plugins should be provided.
