### PR TITLE
Fixed the onerror status

### DIFF
--- a/status.json
+++ b/status.json
@@ -3002,10 +3002,9 @@
     "summary": "Unhandled exceptions trigger the 'window.onerror' callback (or 'self.onerror' inside Workers) for centralized handling.",
     "standardStatus": "Established standard",
     "ieStatus": {
-      "text": "Under Consideration",
+      "text": "Shipped",
       "iePrefixed": "",
-      "ieUnprefixed": "",
-      "priority": "Low"
+      "ieUnprefixed": "10"
     },
     "spec": "html51",
     "msdn": "",


### PR DESCRIPTION
It seems to work since Internet Explorer 10 (and partially since at least Internet Explorer 5).

This is  the code I tried -

``` js
if (window.addEventListener)
 window.addEventListener("error", console.log.bind(console, "addEventListener"));
if (window.attachEvent)
 attachEvent(
  "onerror",
  function ()
  {
   console.log("attachEvent " + arguments[0] + arguments[1] + arguments[2] + arguments[3] + arguments[4]);
   console.log(arguments);
  });
window.onerror =
 function ()
 {
  console.log("onerror " + arguments[0] + arguments[1] + arguments[2] + arguments[3] + arguments[4]);
  console.log(arguments);
  };
setTimeout("throw new Error('j')", 900);
```

Results -

```
addEventListener [object ErrorEvent]
   "addEventListener"
   {
      [functions]: ,
      __proto__: { },
      AT_TARGET: 2,
      bubbles: false,
      BUBBLING_PHASE: 3,
      cancelable: false,
      cancelBubble: false,
      CAPTURING_PHASE: 1,
      colno: 1,
      constructor: { },
      currentTarget: { },
      defaultPrevented: false,
      error: { },
      eventPhase: 2,
      filename: "",
      isTrusted: true,
      lineno: 1,
      message: "j",
      srcElement: { },
      target: { },
      timeStamp: 1462089452583,
      type: "error"
   }

onerror j11Error: j
[object Arguments]
   {
      [functions]: ,
      0: "j",
      1: "",
      2: 1,
      3: 1,
      4: { },
      __proto__: { },
      length: 5
   }
```

Am I missing something?
