### PR TITLE
Change Web Notifications status to Shipped

### DIFF
--- a/status.json
+++ b/status.json
@@ -2248,7 +2248,7 @@
     "summary": "An API for displaying simple notifications to the user.",
     "standardStatus": "Established standard",
     "ieStatus": {
-      "text": "Preview Release",
+      "text": "Shipped",
       "iePrefixed": "",
       "ieUnprefixed": "14316",
       "flag": true


### PR DESCRIPTION
Web Notifications was moved out from behind the flag in the 14342 build. Source: [Edge Changelog](https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14342/) 
