### PR TITLE
Change Web Notifications status to Preview Release

### DIFF
--- a/status.json
+++ b/status.json
@@ -2248,7 +2248,7 @@
     "summary": "An API for displaying simple notifications to the user.",
     "standardStatus": "Established standard",
     "ieStatus": {
-      "text": "Shipped",
+      "text": "Preview Release",
       "iePrefixed": "",
       "ieUnprefixed": "14316",
       "flag": true


### PR DESCRIPTION
Web Notifications are enabled only in the Insider Preview. This revert the changes made in the #402 PR.
