### PR TITLE
update labels for SIMD and async functions

### DIFF
--- a/status.json
+++ b/status.json
@@ -3489,7 +3489,7 @@
     "uservoiceid": 6512244
   },
   {
-    "name": "Async Functions (ES Proposal)",
+    "name": "Async Functions",
     "category": "JavaScript",
     "link": "https://tc39.github.io/ecmascript-asyncawait",
     "summary": "",
@@ -3953,7 +3953,7 @@
     "id": null
   },
   {
-    "name": "SIMD (ES Proposal)",
+    "name": "SIMD",
     "category": "JavaScript",
     "summary": "Enables Single Instruction, Multiple Data instructions to be used from Javascript programs.",
     "link": "https://github.com/johnmccutchan/ecmascript_simd/",

--- a/status.json
+++ b/status.json
@@ -3489,7 +3489,7 @@
     "uservoiceid": 6512244
   },
   {
-    "name": "Async Functions (ES2016)",
+    "name": "Async Functions (ES Proposal)",
     "category": "JavaScript",
     "link": "https://tc39.github.io/ecmascript-asyncawait",
     "summary": "",
@@ -3953,7 +3953,7 @@
     "id": null
   },
   {
-    "name": "SIMD (ES7)",
+    "name": "SIMD (ES Proposal)",
     "category": "JavaScript",
     "summary": "Enables Single Instruction, Multiple Data instructions to be used from Javascript programs.",
     "link": "https://github.com/johnmccutchan/ecmascript_simd/",


### PR DESCRIPTION
SIMD and async functions are still at Stage 3 as of May 2015, meaning it won't be in ES7/ES2016.
This patch updates those labels to "ES Proposal" as folks in #244 find it acceptable.
