### PR TITLE
Updated the High Resolution Time 2 summary

### DIFF
--- a/status.json
+++ b/status.json
@@ -273,7 +273,7 @@
     "name": "High Resolution Time 2",
     "category": "Performance",
     "link": "https://www.w3.org/TR/hr-time-2/",
-    "summary": "An API that provies the current time in sub-millisecond resolution and is not subject to system clock skew or adjustments.",
+    "summary": "An API that provides translation of the current sub-millisecond resolution time between origins.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
       "text": "Shipped",


### PR DESCRIPTION
It adds a translation method. performance.now() existed in level 1 already.
Also fixed a typo (provies to provides).
