### PR TITLE
Changed battery status API priority to low

### DIFF
--- a/status.json
+++ b/status.json
@@ -2826,7 +2826,8 @@
     "ieStatus": {
       "text": "Under Consideration",
       "iePrefixed": "",
-      "ieUnprefixed": ""
+      "ieUnprefixed": "",
+      "priority": "Low"
     },
     "spec": "battery-status",
     "msdn": "",


### PR DESCRIPTION
There are some [substantiated privacy concerns](http://eprint.iacr.org/2015/616.pdf) with this API. Research has shown that in some cases, it can be used to track users even when cookies have been cleared or InPrivate/Incognito browsing was used. Firefox has [removed this API](https://bugzilla.mozilla.org/show_bug.cgi?id=1313580) as a result.

Microsoft Edge is downgrading the priority of this API to low because of these privacy concerns. While it remains in consideration, it's not currently on the roadmap.