### PR TITLE
Shared memory is In Development

### DIFF
--- a/status.json
+++ b/status.json
@@ -3762,7 +3762,7 @@
     "summary": "Shared memory and atomics for ECMAscript.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text": "Under Consideration",
+      "text": "In Development",
       "iePrefixed": "",
       "ieUnprefixed": ""
     },


### PR DESCRIPTION
`SharedArrayBuffer` was [already shipped in ChakraCore 1.4.0](https://github.com/Microsoft/ChakraCore/wiki/Release-Notes#v140). We should be on track to bring this to Web Worker and Service Worker.