### PR TITLE
Removing uservoiceid from "Intersection Observer"

### DIFF
--- a/status.json
+++ b/status.json
@@ -240,8 +240,7 @@
     "msdn": "",
     "wpd": "",
     "demo": "",
-    "id": 5695342691483648,
-    "uservoiceid": 13407852
+    "id": 5695342691483648
   },
   {
     "name": "Resize Observer",


### PR DESCRIPTION
This item is in Preview Release, so it doesn't need the uservoice id