### PR TITLE
Updating id and uservoiceid for async/await

### DIFF
--- a/status.json
+++ b/status.json
@@ -3768,7 +3768,9 @@
     "spec": "es6",
     "msdn": "",
     "wpd": "",
-    "demo": ""
+    "demo": "",
+    "id": 5643236399906816,
+    "uservoiceid": 8511262
   },
   {
     "name": "Array.prototype.includes (ES2016)",


### PR DESCRIPTION
Async/await is now in Chrome 55 and Firefox nightlies, so this will mirror the Chromestatus entry. Also adds the uservoice id.