### PR TITLE
Correcting the unprefixed release for async/await

### DIFF
--- a/status.json
+++ b/status.json
@@ -3762,7 +3762,7 @@
     "ieStatus": {
       "text": "Preview Release",
       "iePrefixed": "",
-      "ieUnprefixed": "15002",
+      "ieUnprefixed": "14986",
       "flag": false
     },
     "spec": "es6",


### PR DESCRIPTION
Async functions were available in [14986](https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/14986), not 15002