### PR TITLE
Add `ISSUE_TEMPLATE.md`

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,4 @@
+:warning: Notes: 
+
+  * This project is *not* the right place to make feature requests or report bugs in Microsoft Edge and/or Internet Explorer. Browser feedback can be provided through the [issue tracker](https://developer.microsoft.com/microsoft-edge/platform/issues/) and on [UserVoice](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer).
+  * For most of the features, the support data for browsers other than Microsoft Edge and Internet Explorer comes from the [Chromium Dashboard](https://www.chromestatus.com), so bugs related to that data should be filed [here](https://github.com/GoogleChrome/chromium-dashboard/issues).


### PR DESCRIPTION
Quite a few users open issues in this repository about either:

 * browser feature requests or browser bugs
 * outdated status data related to other browsers

This PR adds an issue template file containing short notes that explain what to do in the cases mentioned above.

This hopefully will better help users by pointing them to the right place, and reduce the number of wrongly opened issues.

---

Ref: https://github.com/blog/2111-issue-and-pull-request-templates