### PR TITLE
Removing redundant priority for position:sticky

### DIFF
--- a/status.json
+++ b/status.json
@@ -1645,8 +1645,7 @@
     "summary": "position: sticky is a new way to position elements and is conceptually similar to position: fixed. The difference is that a stickily positioned element behaves like position: relative within its parent, until a given offset threshold is met.",
     "standardStatus": "Editor's draft",
     "ieStatus": {
-      "text": "In Development",
-      "priority": "Medium"
+      "text": "In Development"
     },
     "spec": "css-position-3",
     "id": 6190250464378880,


### PR DESCRIPTION
In development, so no priority is needed