### PR TITLE
Fixed a wrong status

### DIFF
--- a/status.json
+++ b/status.json
@@ -4757,7 +4757,7 @@
       "text": "Shipped",
       "ieUnprefixed": "15042"
     },
-    "impl_status_chrome": "Enabled by default",
+    "impl_status_chrome": "No active development",
     "ff_views": {
       "text": "Enabled by default"
     },


### PR DESCRIPTION
Chrome has not implemented Cache-Control: immutable.


The [commit](https://github.com/MicrosoftEdge/Status/commit/ab9090cd2f2fef89d0e68d1880d2c99bcf063037) that updated this data referenced a comment that really discussed a reload behavior fix.
Furthermore, as a result of this reload behavior fix, Chrome does not intend to implement it - https://bugs.chromium.org/p/chromium/issues/detail?id=611416#c46 - at least not until a new evidence arrives.