### PR TITLE
Fix outdated URLs for element and attribute specs

### DIFF
--- a/status.json
+++ b/status.json
@@ -324,7 +324,7 @@
   {
     "name": "<datalist> Element",
     "category": "User input",
-    "link": "https://www.w3.org/html/wg/drafts/html/master/semantics.html#the-list-attribute",
+    "link": "https://w3c.github.io/html/sec-forms.html#the-datalist-element",
     "summary": "Shows a list of pre-defined options to suggest to the user when entering an input element.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -423,7 +423,7 @@
   {
     "name": "<img srcset>",
     "category": "Graphics",
-    "link": "https://w3c.github.io/html/semantics.html#the-img-element",
+    "link": "https://w3c.github.io/html/semantics-embedded-content.html#element-attrdef-img-srcset",
     "summary": "Enable a responsive images solution by providing the browser multiple resources in varying resolutions for a single image.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
@@ -467,7 +467,7 @@
   {
     "name": "<picture> Element",
     "category": "Graphics",
-    "link": "https://w3c.github.io/html/semantics.html#the-picture-element",
+    "link": "https://w3c.github.io/html/semantics-embedded-content.html#the-picture-element",
     "summary": "Enable a responsive images solution by declaring multiple resources for an image using CSS media queries.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
@@ -482,7 +482,7 @@
   {
     "name": "<template> Element",
     "category": "Web Components",
-    "link": "https://w3c.github.io/html/semantics.html#the-template-element",
+    "link": "https://w3c.github.io/html/semantics-scripting.html#the-template-element",
     "summary": "HTML template element to allow creating fragment of inert HTML as a prototype for stamping out DOM (often used in Web Components).",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -497,7 +497,7 @@
   {
     "name": "<meter> Element",
     "category": "Misc",
-    "link": "https://www.w3.org/TR/html5/forms.html#the-meter-element",
+    "link": "https://w3c.github.io/html/sec-forms.html#the-meter-element",
     "summary": "The HTML meter element allows representation of a scalar measurement of a known range, or fractional value, i.e. a gauge. Distinct from the progress element.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -521,7 +521,7 @@
   {
     "name": "selectionDirection attribute on text input elements",
     "category": "User input",
-    "link": "https://www.w3.org/TR/html5/forms.html#dom-textarea/input-selectiondirection",
+    "link": "https://w3c.github.io/html/sec-forms.html#dom-selectionapielements-selectiondirection",
     "summary": "Returns the string corresponding to the current selection direction on text input elements: \"forward\", \"backward\", or \"none\".",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -659,7 +659,7 @@
   {
     "name": "a[download] attribute",
     "category": "File APIs",
-    "link": "https://w3c.github.io/html/semantics.html#element-attrdef-links-download",
+    "link": "https://w3c.github.io/html/links.html#links-created-by-a-and-area-elements",
     "summary": "When used on an <a>, this attribute signifies that the resource it points to should be downloaded by the browser rather than navigating to it.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -687,7 +687,7 @@
   {
     "name": "Audio tracks",
     "category": "Multimedia",
-    "link": "https://w3c.github.io/html/semantics.html#audiotracklist-and-videotracklist-objects",
+    "link": "https://w3c.github.io/html/semantics-embedded-content.html#media-resources-with-multiple-media-tracks",
     "summary": "Adds the ability to get information about multiple audio tracks, and switch between them using the AudioTrack.enabled attributes.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
@@ -701,7 +701,7 @@
   {
     "name": "Video tracks",
     "category": "Multimedia",
-    "link": "https://w3c.github.io/html/semantics.html#audiotracklist-and-videotracklist-objects",
+    "link": "https://w3c.github.io/html/semantics-embedded-content.html#media-resources-with-multiple-media-tracks",
     "summary": "Adds the ability to get information about multiple video tracks, and switch between them using the VideoTrack.selected attributes.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
@@ -2439,7 +2439,7 @@
   {
     "name": "inputmode",
     "category": "User input",
-    "link": "https://w3c.github.io/html/semantics.html#input-modalities-the-inputmode-attribute",
+    "link": "https://w3c.github.io/html/sec-forms.html#input-modalities-the-inputmode-attribute",
     "summary": "The inputmode content attribute is an enumerated attribute that specifies what kind of input mechanism would be most helpful for users entering content into the form control.",
     "standardStatus": "Editor's draft",
     "ieStatus": {
@@ -3096,7 +3096,7 @@
     "name": "WAV Audio Support",
     "category": "Multimedia",
     "summary": "Enables PCM WAV audio support in HTML5 Audio.",
-    "link": "https://w3c.github.io/html/semantics.html#the-audio-element",
+    "link": "https://w3c.github.io/html/semantics-embedded-content.html#the-audio-element",
     "standardStatus": "De-facto standard",
     "ieStatus": {
       "text": "Shipped",
@@ -3525,7 +3525,7 @@
   {
     "name": "Date-related input types",
     "category": "User input",
-    "link": "https://w3c.github.io/html/semantics.html#element-statedef-input-date-and-time",
+    "link": "https://w3c.github.io/html/sec-forms.html#date-state-typedate",
     "summary": "Input controls for picking dates via <input type='date'>,<input type='month'>, and <input type='week'>.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -3545,7 +3545,7 @@
   {
     "name": "Time-related input types",
     "category": "User input",
-    "link": "https://w3c.github.io/html/semantics.html#element-statedef-input-time",
+    "link": "https://w3c.github.io/html/sec-forms.html#time-state-typetime",
     "summary": "Input controls for picking times via <input type='time'>, and <input type='datetime-local'>.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -3565,7 +3565,7 @@
   {
     "name": "<main> element",
     "category": "DOM",
-    "link": "https://w3c.github.io/html/semantics.html#the-main-element",
+    "link": "https://w3c.github.io/html/grouping-content.html#the-main-elementt",
     "summary": "Semantic HTML5 element that represents the main content of the document or application.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -4444,7 +4444,7 @@
   {
     "name": "<menu> Element",
     "category": "Misc",
-    "link": "https://w3c.github.io/html/semantics.html#the-menu-element",
+    "link": "https://w3c.github.io/html/interactive-elements.html#the-menu-element",
     "summary": "An HTML element for toolbars and popup menus.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -4467,7 +4467,7 @@
   {
     "name": "<time> Element",
     "category": "Misc",
-    "link": "https://w3c.github.io/html/semantics.html#the-time-element",
+    "link": "https://w3c.github.io/html/textlevel-semantics.html#the-time-element",
     "summary": "An HTML element for representing dates and times.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -4491,7 +4491,7 @@
   {
     "name": "<data> Element",
     "category": "Misc",
-    "link": "https://w3c.github.io/html/semantics.html#the-data-element",
+    "link": "https://w3c.github.io/html/textlevel-semantics.html#the-data-element",
     "summary": "An HTML element which represents its content in machine-readable and human-readable formats.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -4502,7 +4502,7 @@
   {
     "name": "<output> Element",
     "category": "Misc",
-    "link": "https://w3c.github.io/html/semantics.html#the-output-element",
+    "link": "https://w3c.github.io/html/sec-forms.html#the-output-element",
     "summary": "An HTML element for representing the result of a calculation or user action.",
     "standardStatus": "Established standard",
     "ieStatus": {
@@ -4526,7 +4526,7 @@
   {
     "name": "ol[reversed] attribute",
     "category": "Misc",
-    "link": "https://w3c.github.io/html/semantics.html#element-attrdef-ol-reversed",
+    "link": "https://w3c.github.io/html/grouping-content.html#element-attrdef-ol-reversed",
     "summary": "A boolean attribute that reverses the order of an ordered list when present.",
     "standardStatus": "Established standard",
     "ieStatus": {


### PR DESCRIPTION
Looks like the URL structure for the HTML5 spec changed; made updates to some URLs here so that they don't just land on the index of that entire spec. Note, I couldn't find a suitable URL for scoped styles or the `iframe[seamless]` attribute in the editor's draft of the W3C spec.

@jacobrossi @dstorey @kypflug