### PR TITLE
Updating Clipboard status to  "In Development"

### DIFF
--- a/status.json
+++ b/status.json
@@ -3409,7 +3409,7 @@
     "link": "https://w3c.github.io/clipboard-apis/",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text": "Shipped",
+      "text": "In Development",
       "ieUnprefixed": "15002"
     },
     "spec": "clipboard-apis",


### PR DESCRIPTION
Updating Clipboard status to  "In Development" due to the fact that navigator.clipboard async spec has been merged with legacy Clipboard API spec.