### PR TITLE
Correct Secure Contexts build number

### DIFF
--- a/status.json
+++ b/status.json
@@ -7,7 +7,7 @@
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
       "text": "Preview Release",
-      "ieUnprefixed": "16257"
+      "ieUnprefixed": "15063"
     },
     "id": 6021277022158848
   },

--- a/status.json
+++ b/status.json
@@ -6,7 +6,7 @@
     "summary": "As the web enables more powerful apps, features which enable those apps should only be enabled in contexts which meet a specific security level. This also exposes the APIs that identify if you’re in a secure context.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text": "Preview Release",
+      "text": "Shipped",
       "ieUnprefixed": "15063"
     },
     "id": 6021277022158848


### PR DESCRIPTION
Secure Contexts was implemented in EdgeHTML 15 (15063), not 16257