### PR TITLE
Updating WebAssembly data to remove flag in 16241 (fixes #533)

### DIFF
--- a/status.json
+++ b/status.json
@@ -4719,8 +4719,7 @@
     "summary": "WebAssembly or wasm is a new portable, size- and load-time-efficient format suitable for compilation to the web.",
     "ieStatus": {
       "text": "Preview Release",
-      "ieUnprefixed": "15063",
-      "flag": true
+      "ieUnprefixed": "16241"
     },
     "id": 5453022515691520,
     "uservoiceid": 11423808


### PR DESCRIPTION
WebAssembly is enabled by default in EdgeHTML 16.16241 and higher (reference [Changelog for build 16241](https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/16241/))