### PR TITLE
Form attribute is in preview already

### DIFF
--- a/status.json
+++ b/status.json
@@ -4657,7 +4657,8 @@
     "summary": "Attribute for associating input and submit buttons with a form.",
     "standardStatus": "Established standard",
     "ieStatus": {
-      "text": "In Development"
+      "text": "Preview Release",
+      "ieUnprefixed": "16257"
     },
     "spec": "html51",
     "demo": "https://www.impressivewebs.com/html5-form-attribute/",


### PR DESCRIPTION
See [this twitter conversation](https://twitter.com/MatthiasKurz/status/896280647622426624) where @dstorey confirmed this feature is available in preview builds already.
I checked myself running [this demo](https://www.impressivewebs.com/demo-files/html5-form-attribute/) and yes - it works! :tada: :beers:

However I am not sure which build introduced support - I used 16257 for now because that's the version I tested with. If you know the exact build version let me know so I can update this pull request.

You might also want to update the uservoice ticket status to let people know about the progress:
https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/7327649-add-support-for-the-form-attribute

Unfortunately there is also no entry about this enhancement in the changelog - maybe it should get mentioned there as well?
https://developer.microsoft.com/en-us/microsoft-edge/platform/changelog/desktop/16257/