### PR TITLE
Clarify Safari IDB multiEntry/array support

### DIFF
--- a/status.json
+++ b/status.json
@@ -1394,10 +1394,6 @@
       "value": 1
     },
     "shipped_opera_milestone": true,
-    "safari_views": {
-      "text": "No public signals",
-      "value": 3
-    },
     "spec": "indexeddb",
     "uservoiceid": 8437039
   },


### PR DESCRIPTION
Safari supports multiEntry and array keys. I assume removing this code block will display that properly?

Sources:

- https://caniuse.com/#feat=indexeddb2
- https://wpt.fyi/IndexedDB (note `arraykeypath` and `multientry` tests)