### PR TITLE
Changed the status of Touch Events to Preview

### DIFF
--- a/status.json
+++ b/status.json
@@ -2700,8 +2700,9 @@
     "summary": "Touchscreen input API, originally introduced by Apple on iOS. Support is currently limited to only devices with a touchscreen (can be overridden in about:flags). See Pointer Events for touch, pen, and mouse input across all device types.",
     "standardStatus": "Established standard",
     "ieStatus": {
-      "text": "Shipped",
-      "ieUnprefixed": "10240"
+      "text": "Preview Release",
+      "ieUnprefixed": "10240",
+      "flag": true
     },
     "spec": "touch-events",
     "msdn": "https://developer.mozilla.org/docs/Web/API/Touch_events",


### PR DESCRIPTION
Changed the status of Touch Events to Preview to reflect the actual state of this API.
Fix for #336 until it's enabled everywhere by default and optionally removed from about:flags.