### PR TITLE
Safari and Opera has shipped RTC Data Channels

### DIFF
--- a/status.json
+++ b/status.json
@@ -4418,9 +4418,10 @@
       "text": "Shipped",
       "value": 1
     },
+    "shipped_opera_milestone": true,
     "safari_views": {
-      "text": "No public signals",
-      "value": 3
+      "text": "Shipped",
+      "value": 1
     },
     "uservoiceid": 17929639
   },


### PR DESCRIPTION
As far as I can tell, Safari and Opera have both shipped functioning RTC Data Channels. This PR updates status.json to reflect this. 

Closes #575 