### PR TITLE
Add Picture-in-Picture to the Edge status page

### DIFF
--- a/status.json
+++ b/status.json
@@ -5057,5 +5057,18 @@
     "ieStatus": {
       "text": "Under Consideration"
     }
+  },
+  {
+    "name": "Picture-in-Picture",
+    "category": "Multimedia",
+    "link": "https://wicg.github.io/picture-in-picture/",
+    "summary": "An API for allowing websites to create a floating video window always on top of other windows so that users may continue consuming media while they interact with other content sites, or applications on their device.",
+    "standardStatus": "Editor's draft",
+    "ieStatus": {
+      "text": "Under Consideration"
+    },
+    "impl_status_chrome": "In Development",
+    "id": 5729206566649856,
+    "uservoiceid": 33293761
   }
 ]


### PR DESCRIPTION
I'd like to link to the Edge status page (including Picture-in-Picture) from the upcoming [Picture-in-Picture implementation status page](https://github.com/WICG/picture-in-picture/pull/61)