### PR TITLE
Update the Chrome status for the <keygen> element

### DIFF
--- a/status.json
+++ b/status.json
@@ -3748,7 +3748,7 @@
     "ieStatus": {
       "text": "Not currently planned"
     },
-    "impl_status_chrome": "Enabled by default",
+    "impl_status_chrome": "Removed",
     "shipped_opera_milestone": true,
     "ff_views": {
       "text": "Shipped",


### PR DESCRIPTION
Support for <keygen> was removed in Chrome 57, as of https://chromium.googlesource.com/chromium/src.git/+/5d916f6c6b47472770e03cb483f06a18ca79a0c2

Fixes #584