### PR TITLE
feat(status): track canvas.prototype.toBlob method

### DIFF
--- a/status.json
+++ b/status.json
@@ -5119,5 +5119,27 @@
       "value": 1
     },
     "uservoiceid": 19291531
+  },
+  {
+    "name": "HTML CanvasElement toBlob method",
+    "category": "Graphics",
+    "link": "https://html.spec.whatwg.org/multipage/canvas.html#dom-canvas-toblob",
+    "summary": "Creates a Blob object representing a file containing the image in the canvas, and invokes a callback with a handle to that object.",
+    "standardStatus": "Established standard",
+    "ieStatus": {
+      "text": "Prefixed",
+      "iePrefixed": "10"
+    },
+    "ff_views": {
+      "text": "Shipped",
+      "value": 1
+    },
+    "shipped_opera_milestone": true,
+    "safari_views": {
+      "text": "Preview Release",
+      "value": 1
+    },
+    "id": 4562033294966784,
+    "uservoiceid": 15107964
   }
 ]


### PR DESCRIPTION
Closes #592. See [here](https://github.com/MicrosoftEdge/Status/issues/592#issuecomment-381968042) for more documentation links.