### PR TITLE
Web App Manifest to "Shipped"

### DIFF
--- a/status.json
+++ b/status.json
@@ -3628,7 +3628,7 @@
   {
     "name": "Web Application Manifest",
     "category": "DOM",
-    "summary": "his specification defines a JSON-based manifest, which provides developers with a centralized place to put metadata associated with a web application. On Windows 10, we support submitting web apps with a manifest to the Microsoft Store using packaging tools like PWA Builder or Visual Studio, and are previewing proactive indexing of published PWAs via the Bing crawler.",
+    "summary": "This specification defines a JSON-based manifest, which provides developers with a centralized place to put metadata associated with a web application. On Windows 10, we support submitting web apps with a manifest to the Microsoft Store using packaging tools like PWA Builder or Visual Studio, and are previewing proactive indexing of published PWAs via the Bing crawler.",
     "link": "https://w3c.github.io/manifest/",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {

--- a/status.json
+++ b/status.json
@@ -3628,11 +3628,12 @@
   {
     "name": "Web Application Manifest",
     "category": "DOM",
-    "summary": "This specification defines a JSON-based manifest, which provides developers with a centralized place to put metadata associated with a web application.",
+    "summary": "his specification defines a JSON-based manifest, which provides developers with a centralized place to put metadata associated with a web application. On Windows 10, we support submitting web apps with a manifest to the Microsoft Store using packaging tools like PWA Builder or Visual Studio, and are previewing proactive indexing of published PWAs via the Bing crawler.",
     "link": "https://w3c.github.io/manifest/",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text": "In Development"
+      "text": "Shipped",
+      "ieUnprefixed": "17134"
     },
     "id": 6488656873259008,
     "uservoiceid": 6512948


### PR DESCRIPTION
Beginning in EdgeHTML 17, we support web apps with a web app manifest using packaging tools like PWA Builder or Visual Studio, and are previewing proactive indexing of published PWAs via the Bing crawler.