### PR TITLE
List Same-site cookies in Firefox as 'Shipped'

### DIFF
--- a/status.json
+++ b/status.json
@@ -65,6 +65,10 @@
       "text": "Shipped",
       "ieUnprefixed": "11"
     },
+    "ff_views": {
+      "text": "Shipped",
+      "value": 1
+    },
     "id": 4672634709082112
   },
   {


### PR DESCRIPTION
Firefox 60 introduced support for Same-Site cookies.

Blog post here: https://blog.mozilla.org/security/2018/04/24/same-site-cookies-in-firefox-60/

The release notes of Firefox 60 do not mention the support, but it implemented. See here for more details: https://bugzilla.mozilla.org/show_bug.cgi?id=795346#c58