### PR TITLE
Change status of Screen capture API to In Development

### DIFF
--- a/status.json
+++ b/status.json
@@ -4802,8 +4802,7 @@
     "summary": "Screen Capture API allows a user's display or parts thereof be used as the source of a media stream.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text": "Shipped",
-      "ieUnprefixed": "17134"
+      "text": "In Development"
     },
     "ff_views": {
       "text": "In Development",


### PR DESCRIPTION
It has recently been confirmed that an underlying dependency
to getDisplayMedia (namely the CapturePicker) is not present
on Windows Home installations, but instead only on Windows
Pro and Enterprise.

Since there is no reliable way of detecting if a client is
differentiating between Windows Home and Pro/Enterprise users
without actually triggering screenshare and catching the
error, if any is thrown, it can be considered unsupported.

This closes #632 