### PR TITLE
Clarified the Promise.prototype.finally situation

### DIFF
--- a/status.json
+++ b/status.json
@@ -3337,7 +3337,8 @@
     "summary": "Registers a callback to be invoked when a promise is settled (whether it is fulfilled or rejected), allowing for cleanup of pending or ongoing actions depending on that promise.",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text": "In Development"
+      "text": "Shipped",
+      "ieUnprefixed": "17760"
     },
     "msdn": "https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise/finally",
     "id": 5704570235781120,


### PR DESCRIPTION
It seems to be supported in Edge 18 and BrowserStack shows it was supported in as early as build 17760.

If you have more accurate data (it if matters at all), let me know and I will change the build number.