### PR TITLE
Update prefers-reduced-motion status to shipped in Firefox

### DIFF
--- a/status.json
+++ b/status.json
@@ -5495,6 +5495,10 @@
       "text": "Shipped",
       "value": 1
     },
+    "ff_views": {
+      "text": "Shipped",
+      "value": 1
+    },
     "uservoiceid": 19291531,
     "statusid": 321
   },


### PR DESCRIPTION
Ref #647 . Feature not tracked in Chrome or Firefox platform status.

Firefox Windows bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1365045
Firefox macOS bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1475462