### PR TITLE
Add an entry for signed exchanges.

### DIFF
--- a/status.json
+++ b/status.json
@@ -5663,5 +5663,19 @@
     "impl_status_chrome": "Shipped",
     "uservoiceid": 9081910,
     "statusid": 332
+  },
+  {
+    "name": "Origin-Signed HTTP Exchanges",
+    "link": "https://github.com/WICG/webpackage/",
+    "spec": "web-package-loading",
+    "category": "Network / Connectivity",
+    "summary": "Allows sites to send HTTP request+response pairs (exchanges) that are authoritative for an origin, even when the server itself is not authoritative for that origin.",
+    "standardStatus": "Editor's draft",
+    "ieStatus": {
+      "text": "Under Consideration",
+      "priority": "Low"
+    },
+    "id": 5745285984681984,
+    "statusid": 333
   }
 ]


### PR DESCRIPTION
The ieStatus field is just a guess so far; please update that with your
actual status.

I'm also not certain what I should have put into the "spec" field. https://wicg.github.io/webpackage/loading.html and https://wicg.github.io/webpackage/draft-yasskin-http-origin-signed-responses.html are the two specs that cover this.

@patrickkettner 