### PR TITLE
feat: Deprecate HTML Imports

### DIFF
--- a/status.json
+++ b/status.json
@@ -1398,8 +1398,7 @@
     "summary": "Import HTML documents into other HTML documents (often used in Web Components).",
     "standardStatus": "Working draft or equivalent",
     "ieStatus": {
-      "text": "Under Consideration",
-      "priority": "Low"
+      "text": "Not currently planned"
     },
     "spec": "html-imports",
     "id": 5144752345317376,


### PR DESCRIPTION
They’ve been rejected by both the **W3C** and the **WHATWG** and have since been removed from **Google Chrome** and **Chromium**, which **Microsoft Edge** will be using as its engine in the near‑ish future.

Suffice to say, this is highly unlikely to happen.