### PR TITLE
corrected info on bug reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
 :warning: Notes: 
 
-  * This project is *not* the right place to make feature requests or report bugs in Microsoft Edge and/or Internet Explorer. Browser feedback can be provided through the [issue tracker](https://developer.microsoft.com/microsoft-edge/platform/issues/) and on [UserVoice](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer).
+  * Note that this GitHub project is *not* for making feature requests for or reporting bugs in Internet Explorer or Microsoft Edge. Browser feedback can be provided through the built in `Help and feedback > Send feedback` menu or `alt + shift + i`.
   * For most of the features, the support data for browsers other than Microsoft Edge and Internet Explorer comes from the [Chromium Dashboard](https://www.chromestatus.com), so bugs related to that data should be filed [here](https://github.com/GoogleChrome/chromium-dashboard/issues).


### PR DESCRIPTION
replaced the text referring to the issue tracker and user-voice, and replaced them with instructions on using the built in bug reporting tools as requested in #666